### PR TITLE
Add additional flags for pysamstats.load_pileup

### DIFF
--- a/pysamstats/pileup.py
+++ b/pysamstats/pileup.py
@@ -111,6 +111,10 @@ def load_pileup(type,
                 max_depth=8000,
                 window_size=300,
                 window_offset=None,
+                min_mapq=0,
+                min_baseq=0,
+                no_del=False,
+                no_dup=False,
                 dtype=None,
                 fields=None):
     """Load statistics per genome position, based on read pileups.
@@ -137,7 +141,7 @@ def load_pileup(type,
                            user_fields=fields, alignmentfile=alignmentfile, fafile=fafile,
                            chrom=chrom, start=start, end=end, one_based=one_based,
                            truncate=truncate, stepper=stepper, pad=pad, max_depth=max_depth, window_size=window_size,
-                           window_offset=window_offset)
+                           window_offset=window_offset, min_mapq=min_mapq, min_baseq=min_baseq, no_del=no_del, no_dup=no_dup)
 
 
 load_pileup.__doc__ = load_pileup.__doc__.format(params=_doc_params)

--- a/pysamstats/test/test_pileup.py
+++ b/pysamstats/test/test_pileup.py
@@ -915,6 +915,25 @@ pileup_functions = [
     (pysamstats.load_coverage_gc, 1),
 ]
 
+def test_pileup_kwargs():
+    # check that keyword arguments are being passed through
+    kwargs = {
+        'chrom': 'Pf3D7_01_v3',
+        'start': 2000,
+        'end': 2100,
+        'min_mapq': 1,
+        'min_baseq': 1,
+        'no_del': True,
+        'no_dup': True
+    }
+    for f, needs_ref in pileup_functions:
+        if needs_ref:
+            a = f(Samfile('fixture/test.bam'), Fastafile('fixture/ref.fa'), **kwargs)
+        else:
+            a = f(Samfile('fixture/test.bam'), **kwargs)
+        assert isinstance(a, np.ndarray)
+        assert a.dtype.names is not None
+
 
 def test_pileup_truncate():
     kwargs_notrunc = {'chrom': 'Pf3D7_01_v3',


### PR DESCRIPTION
Include optional flags to pileup.py/load_pileup

- min_mapq=0
- min_baseq=0
- no_del=False
- no_dup=False

This allows for the use of these flags in  all pysamsstats.load_* calls