### PR TITLE
Add pyproject.toml for package build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,9 @@ The easiest way to install pysamstats is via conda, e.g.:
 $ conda install -c bioconda pysamstats
 ```
 
-Alternatively, pysamstats can be installed from source via pip. This requires
-[pysam version 0.11](http://pysam.readthedocs.org/en/latest/) to be
-already installed. E.g.:
+Alternatively, pysamstats can be installed from source via pip. 
 
 ```
-$ pip install pysam==0.11.2.2
 $ pip install pysamstats
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pysam"]
+requires = ["setuptools", "wheel", "pysam (<0.15)"]
 
 [tool.pysamstats]
 name='pysamstats'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ author='Alistair Miles'
 author_email='alimanfoo@googlemail.com'
 url='https://github.com/alimanfoo/pysamstats'
 license='MIT Licenses'
-description="""A Python utility for calculating statistics against genome ' + 
-            'position based on sequence alignments from a SAM, '
-            'BAM or CRAM file."""
+description="""A Python utility for calculating statistics against genome 
+            position based on sequence alignments from a SAM, 
+            BAM or CRAM file."""
 scripts=['scripts/pysamstats']
 classifiers=[
     'Intended Audience :: Developers',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools", "wheel", "pysam"]
+
+[tool.pysamstats]
+name='pysamstats'
+author='Alistair Miles'
+author_email='alimanfoo@googlemail.com'
+url='https://github.com/alimanfoo/pysamstats'
+license='MIT Licenses'
+description="""A Python utility for calculating statistics against genome ' + 
+            'position based on sequence alignments from a SAM, '
+            'BAM or CRAM file."""
+scripts=['scripts/pysamstats']
+classifiers=[
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Topic :: Software Development :: Libraries :: Python Modules'
+]

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
                 'BAM or CRAM file.',
     scripts=['scripts/pysamstats'],
     package_dir={'': '.'},
+    install_requires=[
+        "pysam (<0.15)"
+    ],
     packages=find_packages(),
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hello, [PEP 518](https://www.python.org/dev/peps/pep-0518/) allows for a pyproject.toml file to be included for specifying a minimal set of build requirements. 

This file can be used to instruct pip (versions 10 and up) to install pysam **before** the setup.py script is executed. pysam is removed by pip after building, requiring it to be included in `install_requires` as well.

This makes life easier for unwitting system engineers that deploy software with a dependency to pysamstats. 
