### PR TITLE
[bugfix] const pointers in cython pyx

### DIFF
--- a/pysamstats/opt.pyx
+++ b/pysamstats/opt.pyx
@@ -1873,7 +1873,7 @@ def stat_pileup(PileupStat stat,
                 bint no_del,
                 bint no_dup):
     cdef:
-        bam_pileup1_t** plp
+        const bam_pileup1_t** plp
         bam_pileup1_t* read
         bam1_t* b
         int i, n


### PR DESCRIPTION
* Recent version of HTSlib have introduced const pointers
* recent versions of gcc now show error when assign from a const pointer to a (normal mutable) pointer

This causes package compilation to fail on bioconda with errors about incompatible pointer assignment:
```console
pysamstats/opt.c: In function '__pyx_pf_10pysamstats_3opt_5stat_pileup':
pysamstats/opt.c:40374:15: error: assignment to 'bam_pileup1_t **' from incompatible pointer type 'const bam_pileup1_t **' [-Wincompatible-pointer-types]
40374 |   __pyx_v_plp = __pyx_t_3;
      |               ^
error: command '/opt/conda/conda-bld/pysamstats_1785571487496/_build_env/bin/x86_64-conda-linux-gnu-cc' failed with exit code 1
```
(and a warning when casting as it happens in the next line).
```console
pysamstats/opt.c: In function '__pyx_pf_10pysamstats_3opt_5stat_pileup':
pysamstats/opt.c:40454:18: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
40454 |     __pyx_v_read = (&((__pyx_v_plp[0])[__pyx_v_i]));
      |                  ^

```
(It's these two lines in the .pyx)
```python
    # triggers an error:
    plp = col.plp

    # triggers a warning
    read = &(plp[0][i])
```
(Cythonized into the following C code)
```C
  /* triggers an error: */
  __pyx_t_3 = __pyx_v_col->plp;
  __pyx_v_plp = __pyx_t_3;

   /* triggers a warning: */
   __pyx_v_read = (&((__pyx_v_plp[0])[__pyx_v_i]));
```

This patch add a const qualifier to the first line's pointer (to plp) to keep the compiler happy.
It leaves the second case (read) as-is as that one only causes warnings.